### PR TITLE
Introduce custom JSONFormatter

### DIFF
--- a/logger/example_logger_test.go
+++ b/logger/example_logger_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/sirupsen/logrus"
 	"github.com/grupozap/ligeiro/logger"
+	"github.com/sirupsen/logrus"
 )
 
 func ExampleInfo() {
@@ -18,9 +18,9 @@ func ExampleInfo() {
 
 	json.Unmarshal(buffer.Bytes(), &fields)
 
-	fmt.Println(fields["full_message"])
-	fmt.Println(fields["environment"])
-	fmt.Println(fields["version"])
+	fmt.Println(fields["short_message"])
+	fmt.Println(fields["_environment"])
+	fmt.Println(fields["_app_version"])
 	// Output:
 	// Lorem Ipsum
 	// dev
@@ -37,10 +37,10 @@ func ExampleInfof() {
 
 	json.Unmarshal(buffer.Bytes(), &fields)
 
-	fmt.Println(fields["full_message"])
-	fmt.Println(fields["environment"])
-	fmt.Println(fields["version"])
-	fmt.Println(fields["custom"])
+	fmt.Println(fields["short_message"])
+	fmt.Println(fields["_environment"])
+	fmt.Println(fields["_app_version"])
+	fmt.Println(fields["_custom"])
 	// Output:
 	// Lorem Ipsum
 	// dev

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -8,6 +8,27 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func TestRequiredFieldByGELPSpec(t *testing.T) {
+	t.Log("Comply with GELF 1.1 spec")
+
+	var fields logrus.Fields
+	var buffer bytes.Buffer
+	logrus.SetOutput(&buffer)
+
+	Info("Lorem Ipsum")
+	json.Unmarshal(buffer.Bytes(), &fields)
+
+	if _, exists := fields["full_message"]; !exists {
+		t.Error("GELF spec requires `full_message` field to be defined even it's blank")
+	}
+	if fields["version"] != "1.1" {
+		t.Errorf("Current implemented GELF spec version is 1.1, got: %s", fields["version"])
+	}
+	if _, exists := fields["_version"]; exists {
+		t.Error("Field version can't be set as custom")
+	}
+}
+
 func TestLoggerLevel(t *testing.T) {
 	t.Log("Log with respective level (DEBUG, INFO, WARN, ERROR, FATAL, PANIC)")
 
@@ -60,7 +81,7 @@ func TestLoggerCustomFields(t *testing.T) {
 	customFields.Debug("Lorem Ipsum")
 
 	json.Unmarshal(buffer.Bytes(), &fields)
-	if fields["application"] != "myapp" {
+	if fields["_application"] != "myapp" {
 		t.Errorf("Custom field not logged")
 	}
 
@@ -69,7 +90,7 @@ func TestLoggerCustomFields(t *testing.T) {
 	customFields.Info("Lorem Ipsum")
 
 	json.Unmarshal(buffer.Bytes(), &fields)
-	if fields["application"] != "myapp" {
+	if fields["_application"] != "myapp" {
 		t.Errorf("Custom field not logged")
 	}
 
@@ -78,7 +99,7 @@ func TestLoggerCustomFields(t *testing.T) {
 	customFields.Warn("Lorem Ipsum")
 
 	json.Unmarshal(buffer.Bytes(), &fields)
-	if fields["application"] != "myapp" {
+	if fields["_application"] != "myapp" {
 		t.Errorf("Custom field not logged")
 	}
 
@@ -87,7 +108,7 @@ func TestLoggerCustomFields(t *testing.T) {
 	customFields.Error("Lorem Ipsum")
 
 	json.Unmarshal(buffer.Bytes(), &fields)
-	if fields["application"] != "myapp" {
+	if fields["_application"] != "myapp" {
 		t.Errorf("Custom field not logged")
 	}
 }


### PR DESCRIPTION
This commit make `logger` package use custom `JSONFormatter` in order to
fully comply with GELF spec.

1. Use `_` prefrix for custom fields
2. Always set `full_message` even if it's blank
3. `version` is now for GELF spec version
4. Use `app_version` for application version
5. `short_message` is now default msg field